### PR TITLE
data-link-id tweaks; new data-reset-prompt

### DIFF
--- a/puzzlejs/puzzle.js
+++ b/puzzlejs/puzzle.js
@@ -63,6 +63,7 @@ puzzleModes["default"] = {
     "data-no-input": false,
     "data-no-screenreader": false,
     "data-show-commands": false,
+    "data-reset-prompt": null,
     "data-puzzle-id": null,
     "data-team-id": null,
     "data-player-id": null
@@ -1384,9 +1385,11 @@ function PuzzleEntry(p, index) {
         this.commands.querySelector(".puzzle-about-button").addEventListener("click", e => { this.aboutPopup(); });
         this.commands.querySelector(".puzzle-undo-button").addEventListener("click", e => { this.undoManager.undo(); });
         this.commands.querySelector(".puzzle-redo-button").addEventListener("click", e => { this.undoManager.redo(); });
-        // TODO shouldn't need a reload
-        this.commands.querySelector(".puzzle-reset-button").addEventListener("click", e => { this.prepareToReset(); window.location.reload(); });
-
+        // TODO shouldn't need a reload after reset
+        if (this.options["data-reset-prompt"])
+            this.commands.querySelector(".puzzle-reset-button").addEventListener("click", e => { if (confirm(this.options["data-reset-prompt"])) {this.prepareToReset(); window.location.reload();} });
+        else
+            this.commands.querySelector(".puzzle-reset-button").addEventListener("click", e => { this.prepareToReset(); window.location.reload(); });
         this.container.appendChild(this.commands);
     }
 
@@ -1467,7 +1470,7 @@ function PuzzleGrid(puzzleEntry, options, container, puzzleId) {
             var linkId = s.getAttribute("data-link-id");
             var asel = []
             if (extractId) asel.push("table:not(.copy-only) .extract[data-extract-id='" + extractId + "']");
-            if (linkId) asel.push("table:not(.copy-only) .cell[data-link-id='" + linkId + "']");
+            if (linkId) asel.push("table:not(.copy-only) .link[data-link-id='" + linkId + "']");
 
             if (asel.length > 0) {
                 document.querySelectorAll(asel.join(", ")).forEach(elem => {
@@ -1554,7 +1557,7 @@ function PuzzleGrid(puzzleEntry, options, container, puzzleId) {
             var linkId = primary.getAttribute("data-link-id");
             var asel = []
             if (extractId) asel.push("table:not(.copy-only) .extract[data-extract-id='" + extractId + "']");
-            if (linkId) asel.push("table:not(.copy-only) .cell[data-link-id='" + linkId + "']");
+            if (linkId) asel.push("table:not(.copy-only) .link[data-link-id='" + linkId + "']");
             var elems = asel.length > 0 ? document.querySelectorAll(asel.join(", ")) : [primary];
 
             elems.forEach(elem => {

--- a/reference/reference-options.html
+++ b/reference/reference-options.html
@@ -758,6 +758,12 @@
                 <div class="puzzle-entry" data-mode="slitherlink" data-text="6x4" data-show-commands="true"></div>
             </div>
         </div>
+        <div class="option" data-name="data-reset-prompt">
+            <p>Specifies a prompt to show to confirm clearing the puzzle when the Reset button is pressed. The text of this option is shown in the dialog.</p>
+            <div class="example">
+                <div class="puzzle-entry" data-mode="slitherlink" data-text="6x4" data-show-commands="true" data-reset-prompt="Clear all puzzle content?"></div>
+            </div>
+        </div>
         <div class="option" data-name="data-puzzle-id">
             <p>Allows for a specifically-named identifier to be used for the puzzle, both for saved state in localStorage and for co-op scenarios. When not present, the identifier will be constructed from the page and the index of the puzzle among all <code>.puzzle-entry</code> objects on the page. When needed, the page portion of the identifier will be either the <code>data-puzzle-page-id</code> property of the <code>body</code> element, or if that is not present the <code>window.location.pathname</code> of the page.</p>
             <div class="example">


### PR DESCRIPTION
Propagate linked cell (data-link-id) on reset (as for undo); use .link, not .clue (for both).
New option: data-reset-prompt -- optional text string; if set, shown in confirm dialog on reset.
